### PR TITLE
 Elimina la dependencia de Sentry para corregir el despliegue

### DIFF
--- a/src/lib/payments/stripe-error-handler.ts
+++ b/src/lib/payments/stripe-error-handler.ts
@@ -1,5 +1,4 @@
 import { StripeError } from '@stripe/stripe-js';
-import { Sentry } from '@/lib/sentry'; // Asumiendo que Sentry está configurado así
 
 // --- Tipos ---
 
@@ -94,14 +93,6 @@ export const handleStripeError = (error: StripeError): HandledError => {
     // No incluir `message` por defecto para evitar filtrar PII accidentalmente.
     // Se puede añadir explícitamente si se confirma que es seguro.
   };
-
-  // Enviar a Sentry si está configurado
-  if (Sentry) {
-    Sentry.captureMessage(`Stripe Payment Error: ${code || type}`, {
-      level: 'warning',
-      extra: logPayload,
-    });
-  }
 
   // Loguear en consola para depuración
   console.warn('Stripe Payment Error:', logPayload);


### PR DESCRIPTION
Elimina la importación y el uso del módulo de Sentry en `stripe-error-handler.ts`.

Esto corrige un error de compilación (`Module not found: Can't resolve '@/lib/sentry'`) que ocurría porque el módulo de Sentry no estaba configurado en el proyecto.

La funcionalidad principal de manejo de errores y logging en la consola permanece intacta.